### PR TITLE
Move electron-devtools-installer to prod deps

### DIFF
--- a/angular2/index.js
+++ b/angular2/index.js
@@ -9,12 +9,12 @@ module.exports = {
     '@angular/platform-browser@^2.4.1',
     '@angular/platform-browser-dynamic@^2.4.1',
     '@types/electron@^1.4.30',
+    'electron-devtools-installer@^2.0.1',
     'reflect-metadata@^0.1.9',
     'tslib@^1.4.0',
     'zone.js@^0.7.4'
   ],
   devDependencies: [
-    'electron-devtools-installer@^2.0.1',
     'tslint@^4.2.0',
     'typescript@^2.1.4'
   ],

--- a/react-typescript/index.js
+++ b/react-typescript/index.js
@@ -8,10 +8,10 @@ module.exports = {
     '@types/electron@^1.4.30',
     '@types/react@^0.14.55',
     '@types/react-dom@^0.14.20',
+    'electron-devtools-installer@^2.0.1',
     'tslib@^1.4.0'
   ],
   devDependencies: [
-    'electron-devtools-installer@^2.0.1',
     'tslint@^4.2.0',
     'typescript@^2.1.4'
   ],

--- a/react/index.js
+++ b/react/index.js
@@ -2,12 +2,11 @@ const path = require('path');
 
 module.exports = {
   dependencies: [
+    'electron-devtools-installer@^2.0.1',
     'react@^15.4.1',
     'react-dom@^15.4.1'
   ],
-  devDependencies: [
-    'electron-devtools-installer@^2.0.1'
-  ],
+  devDependencies: [],
   templateDirectory: path.resolve(__dirname, './tmpl'),
   postCopy: (initDir, ora, lintStyle) => {
     // Do nothing

--- a/vue/index.js
+++ b/vue/index.js
@@ -2,11 +2,10 @@ const path = require('path');
 
 module.exports = {
   dependencies: [
+    'electron-devtools-installer@^2.0.1',
     'vue@^2.1.7'
   ],
-  devDependencies: [
-    'electron-devtools-installer@^2.0.1'
-  ],
+  devDependencies: [],
   templateDirectory: path.resolve(__dirname, './tmpl'),
   postCopy: (initDir, ora, lintStyle) => {
     // Do nothing


### PR DESCRIPTION
This is a quick bugfix for something I'm doing next week.  Merging this in immediately after a green build so I can get unblocked.

Reasoning for not waiting for review:
* Urgent bugfix, packaging apps made from these templates is currently impossible
* Unblocks me 😆 
* Minimal scope of change, dependency is still present just will now be included in the generated package.  In an ideal world `electron-devtools-installer` would have a easy technique to not throw errors in prod but also be a noop I.e. not ship itself.  I'm coming up with a solution for this at the moment by exposing an `afterCopy` hook in `electron-devtools-installer` to create a "fake" module at package time that fakes the installer API so your code will become noop