### PR TITLE
Load zonejs & reflect metadata in script tags

### DIFF
--- a/angular2/tmpl/src/bootstrap.ts
+++ b/angular2/tmpl/src/bootstrap.ts
@@ -1,6 +1,3 @@
-import 'zone.js';
-import 'reflect-metadata';
-
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule }  from './app.component';
 

--- a/angular2/tmpl/src/index.html
+++ b/angular2/tmpl/src/index.html
@@ -6,5 +6,7 @@
   <body style="overflow: hidden; background-color: rgba(0,0,0,0); margin: 0" >
     <App/>
   </body>
+  <script src="../node_modules/zone.js/dist/zone.js"></script>
+  <script src="../node_modules/reflect-metadata/Reflect.js"></script>
   <script src="bootstrap.ts"></script>
 </html>


### PR DESCRIPTION
Seem to be hard-to-diagnose problems when they are imported instead of loaded with script tags.

See https://github.com/electron-userland/electron-forge/issues/106 for description of bug. 