### PR TITLE
set emitDecoratorMetadata ts compiler option

### DIFF
--- a/angular2/tmpl/_compilerc
+++ b/angular2/tmpl/_compilerc
@@ -18,7 +18,8 @@
         "noEmitHelpers": true,
         "experimentalDecorators": true,
         "target": "es2015",
-        "module": "commonjs"
+        "module": "commonjs",
+        "emitDecoratorMetadata": true
       }
     },
     "production": {
@@ -38,7 +39,8 @@
         "noEmitHelpers": true,
         "experimentalDecorators": true,
         "target": "es2015",
-        "module": "commonjs"
+        "module": "commonjs",
+        "emitDecoratorMetadata": true
       }
     }
   }

--- a/angular2/tmpl/tsconfig.json
+++ b/angular2/tmpl/tsconfig.json
@@ -18,7 +18,8 @@
     "moduleResolution": "node",
     "pretty": true,
     "target": "es2015",
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDecoratorMetadata": true
   },
   "formatCodeOptions": {
     "indentSize": 2,


### PR DESCRIPTION
Angular recommends setting `emitDecoratorMetadata`=true. This setting is required to get DI working the way that most angular examples online show. 

See https://angular.io/docs/ts/latest/guide/typescript-configuration.html for details. 

I'm unsure where this change belongs though. Playing with it locally, I had to set it in the `.compilerrc` file. Setting it in the `tsconfig.json` file, like all the angular docs say had no effect