### PR TITLE
Fix tsc issues in react-typescript template

### DIFF
--- a/react-typescript/index.js
+++ b/react-typescript/index.js
@@ -8,6 +8,7 @@ module.exports = {
     '@types/electron@^1.4.30',
     '@types/react@^0.14.55',
     '@types/react-dom@^0.14.20',
+    "@types/electron-devtools-installer@^2.0.2",
     'electron-devtools-installer@^2.0.1',
     'tslib@^1.4.0'
   ],

--- a/react-typescript/tmpl/src/index.ts
+++ b/react-typescript/tmpl/src/index.ts
@@ -4,7 +4,7 @@ import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-insta
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow;
+let mainWindow: BrowserWindow | null = null;
 
 const isDevMode = process.execPath.match(/[\\/]electron/);
 

--- a/react-typescript/tmpl/src/index.ts
+++ b/react-typescript/tmpl/src/index.ts
@@ -4,7 +4,7 @@ import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-insta
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow: BrowserWindow | null = null;
+let mainWindow: Electron.BrowserWindow | null = null;
 
 const isDevMode = process.execPath.match(/[\\/]electron/);
 


### PR DESCRIPTION
While running the following does start the app:

```
electron-forge init my-forge-project --template=react-typescript
cd my-forge-project
electron-forge start
```

When opening the project in vscode you can see a couple of `tsc` errors.

This fixes those.