### PR TITLE
pin typescript to 2.1.x

### DIFF
--- a/angular2/index.js
+++ b/angular2/index.js
@@ -16,7 +16,7 @@ module.exports = {
   ],
   devDependencies: [
     'tslint@^4.2.0',
-    'typescript@^2.1.4'
+    'typescript@~2.1.4'
   ],
   templateDirectory: path.resolve(__dirname, './tmpl'),
   postCopy: (initDir, ora, lintStyle) => {

--- a/react-typescript/index.js
+++ b/react-typescript/index.js
@@ -13,7 +13,7 @@ module.exports = {
   ],
   devDependencies: [
     'tslint@^4.2.0',
-    'typescript@^2.1.4'
+    'typescript@~2.1.4'
   ],
   templateDirectory: path.resolve(__dirname, './tmpl'),
   postCopy: (initDir, ora, lintStyle) => {


### PR DESCRIPTION
Current package.json setting for angular2 and react-typescript leads to installing typescript 2.2.1 which is incompatible with (probably) electron-compile and produces error on app startup.