### PR TITLE
Resolving react-typescript tslint issues [lint task and TS/lint version updates]

### DIFF
--- a/react-typescript/index.js
+++ b/react-typescript/index.js
@@ -14,8 +14,8 @@ module.exports = {
     'tslib@^1.4.0',
   ],
   devDependencies: [
-    'tslint@^4.2.0',
-    'typescript@~2.1.4'
+    'tslint@^5.1.0',
+    'typescript@~2.2.2'
   ],
   templateDirectory: path.resolve(__dirname, './tmpl'),
   postCopy: (initDir, ora, lintStyle) => {
@@ -23,7 +23,7 @@ module.exports = {
     if (fs.existsSync(oldIndex)) fs.unlinkSync(oldIndex);
     const packageJSON = require(path.resolve(initDir, 'package.json'));
     packageJSON.main = 'src/index.ts';
-    packageJSON.scripts.lint = 'tslint src';
+    packageJSON.scripts.lint = 'tslint --project tsconfig.json --type-check --force';
     fs.writeFileSync(path.resolve(initDir, 'package.json'), JSON.stringify(packageJSON, null, 2));
   },
 };

--- a/react-typescript/tmpl/src/index.ts
+++ b/react-typescript/tmpl/src/index.ts
@@ -8,7 +8,9 @@ let mainWindow: Electron.BrowserWindow | null = null;
 
 const isDevMode = process.execPath.match(/[\\/]electron/);
 
-if (isDevMode) enableLiveReload({strategy: 'react-hmr'});
+if (isDevMode) {
+  enableLiveReload({strategy: 'react-hmr'});
+}
 
 const createWindow = async () => {
   // Create the browser window.


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge-templates/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR resolves several issues with the react-typescript template. As covered in #29 the lint step does not appear to do anything. Experimenting with tslint led to the above chain of flags. 

Lint Command
-----------
Details on each flag are available [at the tslint docs](https://palantir.github.io/tslint/usage/cli/)

    --project tsconfig.json

has tslint respect the settings from the tsconfig

    --type-check

is included for a couple of reasons. One, without this the linter gives this warning:

 > Linting ApplicationWarning: The 'no-use-before-declare' rule requires type checking

Two, as typescript developers we expect to be able to get a list of compile issues from our application (as evidenced by [myself](https://github.com/electron-userland/electron-forge/issues/205) and #27) and this isn't available without manually passing in the `--type-check` flag. I feel the template *should* cover this even if it didn't have to to satisfy the previous linter warning.

    --force

is required to avoid npm barfing a string of error messages every `electron-forge lint`. The tslint command will have a non-zero return code if any issues are found, which will cause npm to drop a stacktrace. 

Version Updates
-----------
**tslint 4** throws an exception on compile errors with `--type-check` while tslint 5 takes the saner approach of printing them and continuing on, necessary to avoid the npm vomit mentioned above

**Typescript 2.2** introduces the `object` type which is **required** thanks to its use in the electron-compile .d.ts. Running with 2.1 results in this error:

> Error at project_path/node_modules/electron-compile/types/index.d.ts:101:52: Cannot find name 'object'.

[What's new in Typescript 2.2#object-type](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#object-type)

Code Updates
----------
The current tslint.json rules require curly braces after if statements so I've updated the template to comply with those rules.

Testing
------
I didn't see much about your automated testing situation but I have successfully applied these changes to the template and created a new project using it locally. If you want to point me toward some tests I'll be happy to run them.